### PR TITLE
Fix code background for syntax highlight

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1672,13 +1672,16 @@
 	}
 
 	code {
-		background: #f7f7f7;
 		border-radius: 0.35em;
-		border: solid 2px #efefef;
 		font-family: "Courier New", monospace;
 		font-size: 0.9em;
 		margin: 0 0.25em;
 		padding: 0.25em 0.65em;
+	}
+
+	code:not([data-lang]) {
+		background: #f7f7f7;
+		border: solid 2px #efefef;
 	}
 
 	pre {


### PR DESCRIPTION
## Before
![before](https://user-images.githubusercontent.com/695166/36491364-e89e69d2-176d-11e8-8a34-5d74b050a26e.png)

## After
![after](https://user-images.githubusercontent.com/695166/36491376-f25c5286-176d-11e8-81fe-f39965fce953.png)
