### PR TITLE
Add Japanese for 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,6 +1,8 @@
 {{ define "main" }}
     <h1>Page not found</h1>
 
+    <p>ページが見つかりませんでした。トップページは <a href="{{ .Site.BaseURL }}">こちら</a> です。</p>
+
     <p>Uh-oh, you seem to have taken a wrong turn! It looks like this was the result of either:</p>
 
     <ul>


### PR DESCRIPTION
https://github.com/ww24/hugo-strata-theme/issues/2

1行追加しただけの雑な対応だけど、言語設定見る所までやる必要あるだろうか…　いや、無い。