### PR TITLE
Fix deprecated references

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,7 +29,9 @@
 		<li><a href="{{ $.Site.BaseURL }}#contact-form" class="icon fa-envelope-o"><span class="label">Email</span></a></li>
 		{{ end }}
 		{{ if not .Site.Params.rss.hide }}
-		<li><a href="{{ if $.RSSLink }}{{ $.RSSLink }}{{ else }}{{ $.Site.RSSLink }}{{ end }}" class="icon fa-rss" type="application/rss+xml"><span class="label">RSS</span></a></li>
+		{{ with .OutputFormats.Get "RSS" }}
+		<li><a href="{{ .RelPermalink }}" class="icon fa-rss" type="application/rss+xml"><span class="label">RSS</span></a></li>
+		{{ end }}
 		{{ end }}
 	</ul>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -46,16 +46,16 @@
 		{{ end }}
 		{{ end }}
 
-		{{ .Hugo.Generator }}
+		{{ hugo.Generator }}
 
 		{{ "<!--[if lte IE 8]>" | safeHTML }}<script src='{{ .Site.BaseURL }}js/ie/html5shiv.js'></script>{{ "<![endif]-->" | safeHTML}}
 		<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/main.css" />
 		{{ "<!--[if lte IE 8]>" | safeHTML }}<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/ie8.css">{{ "<![endif]-->" | safeHTML}}
 
-		{{ with .RSSLink }}
-		<link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
-		<link href="{{ . }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
+		{{ with .OutputFormats.Get "RSS" }}
+		<link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+		<link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
 		{{ end }}
 		{{ range .Site.Params.custom_css }}
 		<link rel="stylesheet" href="{{ $.Site.BaseURL }}{{ . }}">


### PR DESCRIPTION
Fix deprecated errors on Hugo v0.68.3

```
WARN 2020/03/26 23:26:44 Page.Hugo is deprecated and will be removed in a future release. Use the global hugo function.
```
```
WARN 2020/03/26 23:26:44 Page.RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like: 
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}
```